### PR TITLE
fix: switch flex direction based on size

### DIFF
--- a/css/styles_neu.css
+++ b/css/styles_neu.css
@@ -154,8 +154,6 @@ a:focus {color: #2d3c49; outline: 0;}
 .flexRow {
   display: flex;
   flex-direction: row;
-  
-  flex-wrap: wrap;
   flex-basis: calc(980px * 999 - 100% * 999);
 }
 
@@ -178,9 +176,9 @@ header {
 }
 .flexItem {
   padding: 5px;
-  width: 33%;
   margin-top: 10px;
   justify-content: center;
+  width: 100%;
   /*
   line-height: 150px;
   color: white;
@@ -190,8 +188,8 @@ header {
   */
 }
 @media screen and (max-width: 480px) {
-	.flexItem {
-		width: 100%;
+	.flexRow {
+		flex-direction: column;
 	}
 }
 


### PR DESCRIPTION
This fixes the layout so that the bottom elements are either in next to each other on one line or in a column on small designs:

![Screenshot_20191230_214234](https://user-images.githubusercontent.com/188915/71599962-5ebad480-2b4d-11ea-9efb-37883b2960ae.png)
![Screenshot_20191230_214251](https://user-images.githubusercontent.com/188915/71599963-5ebad480-2b4d-11ea-85e5-4ee909eff301.png)
